### PR TITLE
Add instruction to also uninstall any related executables

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -94,7 +94,7 @@ if [[ -f Gemfile.lock ]]; then
 		echo_info "Current reported version: ${CURRENT_BUNDLER_VERSION}"
 
         	echo_info "Uninstalling current bundler"
-        	gem uninstall bundler --force
+        	gem uninstall bundler --force --executables
 
 		echo_info "Installing bundler, version ${GEM_BUNDLER_VERSION}"
 		gem install bundler -v=$GEM_BUNDLER_VERSION --force


### PR DESCRIPTION
When running previous commit on a bundler-2.0.x environment, the script would present an user interaction:

```
Successfully uninstalled bundler-2.0.1
Remove executables:
	bundler

in addition to the gem? [Yn]
```

This is a problem for automated system, since it may put the script on hold.

The script is updated to include the instruction to also delete any related executable together with the gem.